### PR TITLE
Add marketing sections and interactive FAQ

### DIFF
--- a/dapp/пульс/src/style.css
+++ b/dapp/пульс/src/style.css
@@ -7,6 +7,10 @@
     color-scheme: dark;
   }
 
+  html {
+    scroll-behavior: smooth;
+  }
+
   body {
     @apply min-h-screen bg-bg text-text antialiased font-inter;
   }

--- a/index.html
+++ b/index.html
@@ -32,6 +32,187 @@
         <a href="#lore" class="bg-accent2 text-white font-extrabold px-6 py-3 rounded-xl hover:opacity-90 transition">Читать лор</a>
       </div>
     </section>
+    <section id="how" class="scroll-mt-24 border-t border-grid/60 py-16 md:py-24">
+      <div class="max-w-3xl">
+        <h2 class="text-3xl md:text-4xl font-extrabold">Как это работает</h2>
+        <p class="mt-4 text-lg text-muted md:text-xl">Pulse Protocol создаётся, чтобы превратить рыночные циклы в настраиваемый, прозрачный и доступный поток дохода.</p>
+      </div>
+      <div class="mt-10 grid gap-6 md:grid-cols-3">
+        <div class="card p-6">
+          <span class="text-xs uppercase tracking-wide text-accent">Шаг 1</span>
+          <h3 class="mt-3 text-xl font-semibold">Анализ циклов рынка</h3>
+          <p class="mt-3 text-sm leading-relaxed text-muted">Используются капитализация, волатильность и ритмы рынка.</p>
+        </div>
+        <div class="card p-6">
+          <span class="text-xs uppercase tracking-wide text-accent">Шаг 2</span>
+          <h3 class="mt-3 text-xl font-semibold">Алготрейдинг</h3>
+          <p class="mt-3 text-sm leading-relaxed text-muted">Протокол автоматически совершает сделки от имени пула.</p>
+        </div>
+        <div class="card p-6">
+          <span class="text-xs uppercase tracking-wide text-accent">Шаг 3</span>
+          <h3 class="mt-3 text-xl font-semibold">Рыночные проценты</h3>
+          <p class="mt-3 text-sm leading-relaxed text-muted">Пока ликвидность в пуле — начисляется доход.</p>
+        </div>
+      </div>
+    </section>
+    <section id="apr" class="scroll-mt-24 border-t border-grid/60 py-16 md:py-24">
+      <div class="max-w-3xl">
+        <h2 class="text-3xl md:text-4xl font-extrabold">Доходность (APR)</h2>
+        <p class="mt-4 text-muted">Выбирайте пул по доходности и риску. Доступны USDT, ETH, BTC.</p>
+      </div>
+      <div class="mt-10 grid gap-6 md:grid-cols-3">
+        <article class="card p-6">
+          <h3 class="text-xl font-semibold">USDT пул — 6–8% APR</h3>
+          <p class="mt-3 text-sm text-muted">Ликвидность: $— · Риск: низкий</p>
+          <p class="mt-4 text-sm leading-relaxed text-muted">Действия: «Вложить» · «Подробнее».</p>
+        </article>
+        <article class="card p-6">
+          <h3 class="text-xl font-semibold">ETH пул — 4–6% APR</h3>
+          <p class="mt-3 text-sm text-muted">Ликвидность: $— · Риск: средний</p>
+          <p class="mt-4 text-sm leading-relaxed text-muted">Действия: «Вложить» · «Подробнее».</p>
+        </article>
+        <article class="card p-6">
+          <h3 class="text-xl font-semibold">BTC пул — 3–5% APR</h3>
+          <p class="mt-3 text-sm text-muted">Ликвидность: $— · Риск: средний</p>
+          <p class="mt-4 text-sm leading-relaxed text-muted">Действия: «Вложить» · «Подробнее».</p>
+        </article>
+      </div>
+      <p class="mt-6 text-sm text-muted italic">Примечание: значения примерные для макета.</p>
+    </section>
+    <section id="deposit" class="scroll-mt-24 border-t border-grid/60 py-16 md:py-24">
+      <div class="grid gap-10 lg:grid-cols-[1.4fr,1fr]">
+        <div>
+          <h2 class="text-3xl md:text-4xl font-extrabold">Мой депозит</h2>
+          <p class="mt-4 text-muted">Баланс, начисления и действия «Пополнить/Вывести» собраны в одном месте, чтобы депозит всегда был под контролем.</p>
+          <div class="mt-8 grid gap-4 sm:grid-cols-2">
+            <div class="card p-5">
+              <span class="text-xs uppercase tracking-wide text-muted">Депозит</span>
+              <p class="mt-2 text-2xl font-semibold">$—</p>
+            </div>
+            <div class="card p-5">
+              <span class="text-xs uppercase tracking-wide text-muted">Доход YTD</span>
+              <p class="mt-2 text-2xl font-semibold">— %</p>
+            </div>
+            <div class="card p-5">
+              <span class="text-xs uppercase tracking-wide text-muted">Награды</span>
+              <p class="mt-2 text-2xl font-semibold">$—</p>
+            </div>
+            <div class="card p-5">
+              <span class="text-xs uppercase tracking-wide text-muted">Комиссии</span>
+              <p class="mt-2 text-2xl font-semibold">$—</p>
+            </div>
+          </div>
+          <p class="mt-6 text-sm leading-relaxed text-muted">Действия: «Пополнить» · «Вывести» · «История».</p>
+          <p class="mt-4 text-sm leading-relaxed text-muted">Вывод ликвидности возможен в любой момент при доступности пула.</p>
+          <a href="#app" class="mt-6 inline-flex items-center justify-center rounded-xl bg-accent px-6 py-3 font-extrabold text-bg transition hover:opacity-90">Перейти к приложению</a>
+        </div>
+        <div class="space-y-6">
+          <div class="card p-6">
+            <h3 class="text-lg font-semibold">Процент на стороне пула</h3>
+            <p class="mt-3 text-sm leading-relaxed text-muted">Пока ликвидность в протоколе — вы получаете рыночные проценты, рассчитанные алгоритмом на циклах и капитализации.</p>
+          </div>
+          <div class="card p-6">
+            <h3 class="text-lg font-semibold">Доступ к аналитике</h3>
+            <p class="mt-3 text-sm leading-relaxed text-muted">TradingView индикатор и e-mail уведомления помогают отслеживать сигналы входа и выхода.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section id="app" class="scroll-mt-24 border-t border-grid/60 py-16 md:py-24">
+      <div class="grid gap-10 lg:grid-cols-[1.4fr,1fr]">
+        <div>
+          <h2 class="text-3xl md:text-4xl font-extrabold">Интерфейс dApp</h2>
+          <p class="mt-4 text-muted">Вкладки «Пулы», «Мой депозит» и «История» помогают управлять ликвидностью, следить за начислениями и действиями.</p>
+          <div class="mt-8 space-y-4">
+            <div class="card p-5">
+              <h3 class="text-lg font-semibold">Пулы</h3>
+              <p class="mt-2 text-sm leading-relaxed text-muted">Обзор всех пулов с фильтрами и сортировкой по APR.</p>
+            </div>
+            <div class="card p-5">
+              <h3 class="text-lg font-semibold">Мой депозит</h3>
+              <p class="mt-2 text-sm leading-relaxed text-muted">Баланс, начисления и быстрые действия «Пополнить/Вывести».</p>
+            </div>
+            <div class="card p-5">
+              <h3 class="text-lg font-semibold">История</h3>
+              <p class="mt-2 text-sm leading-relaxed text-muted">Транзакции пополнений, выводов и наград фиксируются в одном журнале.</p>
+            </div>
+          </div>
+          <a href="/dapp/пульс/" class="mt-8 inline-flex items-center justify-center rounded-xl bg-accent px-6 py-3 font-extrabold text-bg transition hover:opacity-90">Открыть интерфейс</a>
+        </div>
+        <div class="card p-6">
+          <h3 class="text-lg font-semibold">Подписка на e-mail сигналы</h3>
+          <p class="mt-3 text-sm leading-relaxed text-muted">Каждый сигнал дублируется на почту с деталями входа. Endpoint <code class="rounded bg-surface/70 px-2 py-1 text-xs text-muted">POST /api/subscribe-email</code> принимает адрес подписчика.</p>
+          <form id="subscribe-form" class="mt-6 space-y-4" novalidate>
+            <label for="subscribe-email" class="block text-sm font-semibold uppercase tracking-wide text-muted">E-mail</label>
+            <div class="flex flex-col gap-3 sm:flex-row">
+              <input id="subscribe-email" name="email" type="email" autocomplete="email" required placeholder="you@example.com" class="w-full rounded-xl border border-grid/50 bg-surface/80 px-4 py-3 text-base text-text placeholder:text-muted/60 transition focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-bg" />
+              <button id="subscribe-button" type="submit" class="inline-flex items-center justify-center rounded-xl bg-accent px-6 py-3 font-extrabold text-bg transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60">Подписаться</button>
+            </div>
+            <p id="subscribe-status" class="text-sm text-muted" aria-live="polite"></p>
+          </form>
+          <p class="mt-4 text-xs uppercase tracking-wide text-muted">Можно отписаться в любой момент — подписки следуют лучшим практикам безопасности.</p>
+        </div>
+      </div>
+    </section>
+    <section id="lore" class="scroll-mt-24 border-t border-grid/60 py-16 md:py-24">
+      <div class="card mx-auto max-w-4xl p-8">
+        <h2 class="text-3xl md:text-4xl font-extrabold">Лор проекта</h2>
+        <p class="mt-4 text-lg leading-relaxed text-muted">Pulse Protocol — сердце децентрализованного рынка. Оно улавливает ритм капитализации и превращает каждое сокращение в поток дохода.</p>
+        <p class="mt-4 text-lg leading-relaxed text-muted">Алгоритм работает непрерывно, а ликвидность пользователей остаётся в безопасности смарт-контрактов.</p>
+      </div>
+    </section>
+    <section id="faq" class="scroll-mt-24 border-t border-grid/60 py-16 md:py-24">
+      <div class="max-w-3xl">
+        <h2 class="text-3xl md:text-4xl font-extrabold">FAQ</h2>
+        <p class="mt-4 text-muted">Мы собрали короткие ответы на частые вопросы о доходности, ликвидности и уведомлениях.</p>
+      </div>
+      <div class="mt-10 space-y-4">
+        <div class="card p-6">
+          <button type="button" class="flex w-full items-center justify-between gap-6 text-left" data-accordion-trigger aria-expanded="true" aria-controls="faq-panel-1" id="faq-trigger-1">
+            <span class="text-lg font-semibold">Как начисляются проценты?</span>
+            <svg data-accordion-icon class="h-5 w-5 shrink-0 rotate-180 text-accent transition-transform duration-300" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.25a.75.75 0 01-1.06 0L5.21 8.29a.75.75 0 01.02-1.08z" clip-rule="evenodd" />
+            </svg>
+          </button>
+          <div id="faq-panel-1" class="mt-4 text-sm leading-relaxed text-muted" role="region" aria-labelledby="faq-trigger-1" aria-hidden="false">
+            <p>Проценты начисляются динамически в соответствии с рынком, пока ликвидность остаётся в пуле.</p>
+          </div>
+        </div>
+        <div class="card p-6">
+          <button type="button" class="flex w-full items-center justify-between gap-6 text-left" data-accordion-trigger aria-expanded="false" aria-controls="faq-panel-2" id="faq-trigger-2">
+            <span class="text-lg font-semibold">Можно ли вывести ликвидность?</span>
+            <svg data-accordion-icon class="h-5 w-5 shrink-0 text-accent transition-transform duration-300" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.25a.75.75 0 01-1.06 0L5.21 8.29a.75.75 0 01.02-1.08z" clip-rule="evenodd" />
+            </svg>
+          </button>
+          <div id="faq-panel-2" class="mt-4 hidden text-sm leading-relaxed text-muted" role="region" aria-labelledby="faq-trigger-2" aria-hidden="true">
+            <p>Вывод ликвидности возможен в любой момент, когда пул доступен, без блокировок средств.</p>
+          </div>
+        </div>
+        <div class="card p-6">
+          <button type="button" class="flex w-full items-center justify-between gap-6 text-left" data-accordion-trigger aria-expanded="false" aria-controls="faq-panel-3" id="faq-trigger-3">
+            <span class="text-lg font-semibold">Как приходят сигналы?</span>
+            <svg data-accordion-icon class="h-5 w-5 shrink-0 text-accent transition-transform duration-300" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.25a.75.75 0 01-1.06 0L5.21 8.29a.75.75 0 01.02-1.08z" clip-rule="evenodd" />
+            </svg>
+          </button>
+          <div id="faq-panel-3" class="mt-4 hidden text-sm leading-relaxed text-muted" role="region" aria-labelledby="faq-trigger-3" aria-hidden="true">
+            <p>Сигналы отображаются на графике индикатора и дублируются на e-mail с подробностями входа.</p>
+          </div>
+        </div>
+        <div class="card p-6">
+          <button type="button" class="flex w-full items-center justify-between gap-6 text-left" data-accordion-trigger aria-expanded="false" aria-controls="faq-panel-4" id="faq-trigger-4">
+            <span class="text-lg font-semibold">Что доступно в приложении?</span>
+            <svg data-accordion-icon class="h-5 w-5 shrink-0 text-accent transition-transform duration-300" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.25a.75.75 0 01-1.06 0L5.21 8.29a.75.75 0 01.02-1.08z" clip-rule="evenodd" />
+            </svg>
+          </button>
+          <div id="faq-panel-4" class="mt-4 hidden text-sm leading-relaxed text-muted" role="region" aria-labelledby="faq-trigger-4" aria-hidden="true">
+            <p>Вкладки «Пулы», «Мой депозит» и «История» дают доступ к доходности, балансу и журналу транзакций.</p>
+          </div>
+        </div>
+      </div>
+    </section>
     <section id="indicator" class="py-16 md:py-24 space-y-10">
       <div class="grid gap-6 lg:grid-cols-[2fr,1fr]">
         <div class="card p-6">


### PR DESCRIPTION
## Summary
- add home page sections for how it works, APR, deposit, dApp, lore, and FAQ with anchor-friendly layout and responsive styling
- implement FAQ accordion behaviour and an email subscription form with basic validation plus smooth scrolling support

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d27f6af4288320b09a93cde326049a