### PR TITLE
Add crypto ticker with live quotes

### DIFF
--- a/dapp/пульс/src/style.css
+++ b/dapp/пульс/src/style.css
@@ -41,4 +41,75 @@
   .card {
     @apply border border-grid/40 bg-card/80 backdrop-blur rounded-2xl shadow-card;
   }
+
+  .ticker-container {
+    @apply relative flex items-center overflow-hidden border-y border-grid/40 bg-card/80 px-4 py-2 text-xs text-muted md:text-sm;
+  }
+
+  .ticker-content {
+    display: inline-flex;
+    align-items: center;
+    gap: 2.5rem;
+    white-space: nowrap;
+    animation: ticker-scroll 40s linear infinite;
+  }
+
+  .ticker-content:hover {
+    animation-play-state: paused;
+  }
+
+  .ticker-content.is-empty {
+    animation: none;
+    justify-content: center;
+    gap: 1rem;
+  }
+
+  .ticker-content.has-message .ticker-message {
+    margin-right: 2rem;
+  }
+
+  .ticker-item {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.75rem;
+    padding-inline: 1.5rem;
+    color: #f3f4fa;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .ticker-symbol {
+    font-weight: 700;
+    letter-spacing: 0.08em;
+  }
+
+  .ticker-price {
+    color: #ffffff;
+  }
+
+  .ticker-change {
+    font-variant-numeric: tabular-nums;
+  }
+
+  .ticker-change--positive {
+    color: #46c078;
+  }
+
+  .ticker-change--negative {
+    color: #dc5a78;
+  }
+
+  .ticker-message {
+    font-weight: 600;
+    color: #e6e7ed;
+  }
+}
+
+@keyframes ticker-scroll {
+  0% {
+    transform: translateX(0);
+  }
+
+  100% {
+    transform: translateX(-50%);
+  }
 }

--- a/index.html
+++ b/index.html
@@ -38,6 +38,9 @@
       </nav>
     </div>
   </header>
+  <div id="crypto-ticker" class="ticker-container">
+    <div id="ticker-content" class="ticker-content"></div>
+  </div>
   <div id="mobile-menu" class="fixed inset-0 z-50 hidden md:hidden" aria-hidden="true">
     <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" data-menu-overlay></div>
     <div


### PR DESCRIPTION
## Summary
- add a crypto ticker placeholder in the landing page layout with supporting styles for continuous scrolling content
- integrate a CoinGecko-powered ticker refresh with graceful fallback messaging and scheduling alongside existing dashboard updates

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2a0031df483209e643725a7f7235e