### PR TITLE
Use Intl currency formatting for ticker prices

### DIFF
--- a/dapp/пульс/src/main.js
+++ b/dapp/пульс/src/main.js
@@ -340,13 +340,14 @@ function formatTickerPrice(value) {
   }
 
   const formatter = new Intl.NumberFormat('ru-RU', {
+    style: 'currency',
+    currency: 'USD',
+    currencyDisplay: 'narrowSymbol',
     minimumFractionDigits,
     maximumFractionDigits
   });
 
-  const formatted = formatter.format(value).replace(/\u00A0/g, '\u202F');
-
-  return `$${formatted}`;
+  return formatter.format(value).replace(/\u00A0/g, '\u202F').trim();
 }
 
 function renderChart(data) {


### PR DESCRIPTION
## Summary
- format ticker prices using `Intl.NumberFormat` currency options instead of manually prefixing the dollar sign
- normalize spacing in the formatted price output so the ticker shows a single currency symbol

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2ad8a2e708320a5f08de3e1a252fa