### PR TITLE
Add hero animation with reduced motion support

### DIFF
--- a/dapp/пульс/src/style.css
+++ b/dapp/пульс/src/style.css
@@ -113,3 +113,36 @@
     transform: translateX(-50%);
   }
 }
+
+@keyframes hero-reveal {
+  0% {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@layer utilities {
+  [data-hero-ready] [data-hero-item] {
+    opacity: 0;
+    transform: translateY(24px);
+    will-change: opacity, transform;
+  }
+
+  [data-hero-ready] [data-hero-item].is-hero-visible {
+    animation: hero-reveal 0.75s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+    animation-delay: var(--hero-delay, 0ms);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-hero] [data-hero-item] {
+    opacity: 1 !important;
+    transform: none !important;
+    animation: none !important;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -75,13 +75,13 @@
     </div>
   </div>
   <main class="container mx-auto px-6">
-    <section class="py-16 md:py-24">
-      <h1 class="text-4xl md:text-6xl font-extrabold leading-tight max-w-4xl">Пульс рынка под контролем</h1>
-      <p class="text-muted mt-4 max-w-3xl">
+    <section class="py-16 md:py-24" data-hero>
+      <h1 class="text-4xl md:text-6xl font-extrabold leading-tight max-w-4xl" data-hero-item>Пульс рынка под контролем</h1>
+      <p class="text-muted mt-4 max-w-3xl" data-hero-item>
         Алгоритм на циклах и капитализации торгует от имени пула ликвидности.
         Пока средства в протоколе — вы получаете рыночные проценты.
       </p>
-      <div class="mt-6 flex gap-3">
+      <div class="mt-6 flex gap-3" data-hero-item>
         <a href="#deposit" class="bg-accent text-bg font-extrabold px-6 py-3 rounded-xl hover:opacity-90 transition">Вложить ликвидность</a>
         <a href="#lore" class="bg-accent2 text-white font-extrabold px-6 py-3 rounded-xl hover:opacity-90 transition">Читать лор</a>
       </div>


### PR DESCRIPTION
## Summary
- add data attributes in the landing hero section to allow targeted animation triggers
- define hero reveal keyframes and utility rules with a prefers-reduced-motion fallback
- initialize the hero animation from main.js with IntersectionObserver and reduced-motion handling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2b9c084c08320b6e6f2b602b37c2b