### PR TITLE
Add coin summary card for active signal

### DIFF
--- a/dapp/пульс/src/style.css
+++ b/dapp/пульс/src/style.css
@@ -102,6 +102,66 @@
     font-weight: 600;
     color: #e6e7ed;
   }
+
+  .coin-summary {
+    @apply flex flex-col gap-6 p-5 md:p-6;
+  }
+
+  .coin-summary__header {
+    @apply flex flex-col gap-4 md:flex-row md:items-start md:justify-between;
+  }
+
+  .coin-summary__label {
+    @apply text-xs uppercase tracking-wide text-muted;
+  }
+
+  .coin-summary__asset {
+    @apply text-2xl font-semibold text-text;
+  }
+
+  .coin-summary__price-block {
+    @apply flex flex-col items-start gap-2 text-left md:items-end md:text-right;
+  }
+
+  .coin-summary__price {
+    @apply text-3xl font-bold tracking-tight text-text;
+  }
+
+  .coin-summary__ticker {
+    @apply ml-2 align-middle text-sm font-semibold uppercase tracking-wide text-muted;
+  }
+
+  .coin-summary__change {
+    @apply inline-flex items-center rounded-full bg-surface/70 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-muted transition-colors;
+  }
+
+  .coin-summary__change--positive {
+    @apply bg-success/10 text-success;
+  }
+
+  .coin-summary__change--negative {
+    @apply bg-danger/10 text-danger;
+  }
+
+  .coin-summary__meta {
+    @apply flex flex-wrap items-center gap-x-4 gap-y-2 text-xs uppercase tracking-wide text-muted;
+  }
+
+  .coin-summary__grid {
+    @apply grid gap-4 sm:grid-cols-2 xl:grid-cols-3;
+  }
+
+  .coin-summary__metric {
+    @apply rounded-xl bg-surface/70 p-4;
+  }
+
+  .coin-summary__metric-label {
+    @apply text-[11px] uppercase tracking-wide text-muted;
+  }
+
+  .coin-summary__metric-value {
+    @apply mt-2 break-words text-sm font-semibold text-text;
+  }
 }
 
 @keyframes ticker-scroll {

--- a/index.html
+++ b/index.html
@@ -281,6 +281,49 @@
             </div>
           </div>
           <div class="mt-6 h-[320px] md:h-[420px]" id="chart-root"></div>
+          <div id="coin-summary-card" class="card mt-6 coin-summary">
+            <div class="coin-summary__header">
+              <div>
+                <div class="coin-summary__label">Монета</div>
+                <div id="coin-summary-asset" class="coin-summary__asset">—</div>
+              </div>
+              <div class="coin-summary__price-block">
+                <div id="coin-summary-price" class="coin-summary__price">—</div>
+                <div id="coin-summary-change" class="coin-summary__change">—</div>
+              </div>
+            </div>
+            <div class="coin-summary__meta">
+              <span id="coin-summary-timeframe">Таймфрейм —</span>
+              <span id="coin-summary-updated">Обновлено —</span>
+              <span id="coin-summary-coin">CoinGecko ID —</span>
+            </div>
+            <div class="coin-summary__grid">
+              <div class="coin-summary__metric">
+                <div class="coin-summary__metric-label">Тип сигнала</div>
+                <div id="coin-summary-signal-type" class="coin-summary__metric-value text-muted">—</div>
+              </div>
+              <div class="coin-summary__metric">
+                <div class="coin-summary__metric-label">Цена входа</div>
+                <div id="coin-summary-entry" class="coin-summary__metric-value">—</div>
+              </div>
+              <div class="coin-summary__metric">
+                <div class="coin-summary__metric-label">R/R</div>
+                <div id="coin-summary-rr" class="coin-summary__metric-value">—</div>
+              </div>
+              <div class="coin-summary__metric">
+                <div class="coin-summary__metric-label">Take-profit</div>
+                <div id="coin-summary-take-profit" class="coin-summary__metric-value">—</div>
+              </div>
+              <div class="coin-summary__metric">
+                <div class="coin-summary__metric-label">Stop-loss</div>
+                <div id="coin-summary-stop-loss" class="coin-summary__metric-value">—</div>
+              </div>
+              <div class="coin-summary__metric">
+                <div class="coin-summary__metric-label">Время сигнала</div>
+                <div id="coin-summary-signal-time" class="coin-summary__metric-value">—</div>
+              </div>
+            </div>
+          </div>
         </div>
         <div class="space-y-6">
           <div class="card p-6">


### PR DESCRIPTION
## Summary
- add a reusable coin summary card under the indicator chart
- style the summary card to align with existing dashboard visuals
- render price, change and active signal metrics in the summary while keeping it synced with refreshes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2b9caaa6c8320951366531f6c6522