### PR TITLE
Return 204 when webhook history is empty

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -131,7 +131,7 @@ app.post('/api/zapier-hook', async (req, res) => {
 
 app.get('/api/zapier-hook/latest', (req, res) => {
   if (history.length === 0) {
-    return res.status(404).json({ error: 'No events received yet' });
+    return res.status(204).end();
   }
 
   return res.json(history[0]);


### PR DESCRIPTION
## Summary
- update the latest Zapier webhook endpoint to respond with HTTP 204 when no events have been stored

## Testing
- npm run dev:server
- curl -i http://localhost:3001/api/zapier-hook/latest

------
https://chatgpt.com/codex/tasks/task_e_68d2ed078cd08320bbc94ef57ec91b77