### PR TITLE
Add automation webhook port indicator

### DIFF
--- a/dapp/пульс/src/style.css
+++ b/dapp/пульс/src/style.css
@@ -38,6 +38,30 @@
     @apply inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide;
   }
 
+  .port-indicator {
+    @apply inline-flex items-center gap-2 rounded-full border border-grid/40 bg-surface/70 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-muted transition-colors;
+  }
+
+  .port-indicator__label {
+    @apply text-muted;
+  }
+
+  .port-indicator__value {
+    @apply font-mono text-xs;
+  }
+
+  .port-indicator__status {
+    @apply text-xs;
+  }
+
+  .port-indicator--ok {
+    @apply border-success/40 bg-success/10 text-success;
+  }
+
+  .port-indicator--error {
+    @apply border-danger/40 bg-danger/10 text-danger;
+  }
+
   .card {
     @apply border border-grid/40 bg-card/80 backdrop-blur rounded-2xl shadow-card;
   }

--- a/index.html
+++ b/index.html
@@ -356,6 +356,15 @@
                 <span id="automation-status-badge" class="badge hidden">—</span>
               </div>
               <p id="automation-status" class="text-xs uppercase tracking-wide text-muted hidden"></p>
+              <div
+                id="automation-port-indicator"
+                class="port-indicator hidden"
+                aria-live="polite"
+              >
+                <span class="port-indicator__label">Webhook порт</span>
+                <span class="port-indicator__value">—</span>
+                <span class="port-indicator__status">—</span>
+              </div>
             </div>
             <div id="signal-details" class="mt-4 text-sm leading-relaxed text-muted">Выберите сигнал, чтобы увидеть рыночный контекст и уровни управления риском.</div>
           </div>


### PR DESCRIPTION
## Summary
- add a webhook port indicator to the signal details card
- render automation port availability alongside the automation status refresh logic
- style the indicator for success and error states

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2ee724268832080eadb144c31f3c8