### PR TITLE
Add automation port status indicator

### DIFF
--- a/dapp/пульс/src/style.css
+++ b/dapp/пульс/src/style.css
@@ -38,6 +38,22 @@
     @apply inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide;
   }
 
+  .port-indicator {
+    @apply mt-2 inline-flex items-center gap-2 rounded-xl border border-grid/40 bg-surface/80 px-3 py-2 text-[11px] font-semibold uppercase tracking-wide text-muted transition-colors;
+  }
+
+  .port-indicator--ok {
+    @apply border-success/40 bg-success/10 text-success;
+  }
+
+  .port-indicator--error {
+    @apply border-danger/40 bg-danger/10 text-danger;
+  }
+
+  .port-indicator--pending {
+    @apply border-grid/40 bg-surface/70 text-muted;
+  }
+
   .card {
     @apply border border-grid/40 bg-card/80 backdrop-blur rounded-2xl shadow-card;
   }

--- a/index.html
+++ b/index.html
@@ -356,6 +356,11 @@
                 <span id="automation-status-badge" class="badge hidden">—</span>
               </div>
               <p id="automation-status" class="text-xs uppercase tracking-wide text-muted hidden"></p>
+              <div
+                id="automation-port-indicator"
+                class="port-indicator hidden"
+                aria-live="polite"
+              ></div>
             </div>
             <div id="signal-details" class="mt-4 text-sm leading-relaxed text-muted">Выберите сигнал, чтобы увидеть рыночный контекст и уровни управления риском.</div>
           </div>


### PR DESCRIPTION
## Summary
- add a port status indicator to the automation details card
- render webhook port availability based on the resolved port and fetch outcome
- style the indicator for pending, success, and error states

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2ee72ea408320a6b4d9e7756c2e48