### PR TITLE
Add webhook insights panel for automation data

### DIFF
--- a/index.html
+++ b/index.html
@@ -367,6 +367,14 @@
               </div>
             </div>
             <div id="signal-details" class="mt-4 text-sm leading-relaxed text-muted">Выберите сигнал, чтобы увидеть рыночный контекст и уровни управления риском.</div>
+            <div id="automation-insights" class="mt-6 hidden">
+              <div class="flex flex-col gap-2">
+                <span class="text-xs uppercase tracking-wide text-muted">Webhook отчёт</span>
+                <p id="automation-insights-message" class="text-sm font-semibold text-text"></p>
+                <p id="automation-insights-timestamp" class="text-xs text-muted"></p>
+              </div>
+              <div id="automation-insights-grid" class="mt-4 grid gap-3 sm:grid-cols-2"></div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add a webhook insights panel to the automation card that surfaces the latest alert message, timestamps, and metrics
- normalise webhook payloads to extract trading pair, price, MVRVZ ratios, and delivery status for display
- hide the insights card gracefully when no webhook data is available

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d64b8712688320b6c5bafc740aea78