### PR TITLE
Add persistent webhook signal history view

### DIFF
--- a/index.html
+++ b/index.html
@@ -367,6 +367,30 @@
               </div>
             </div>
             <div id="signal-details" class="mt-4 text-sm leading-relaxed text-muted">Выберите сигнал, чтобы увидеть рыночный контекст и уровни управления риском.</div>
+            <div id="automation-insights" class="mt-6 hidden">
+              <div class="flex flex-col gap-2">
+                <span class="text-xs uppercase tracking-wide text-muted">Webhook отчёт</span>
+                <p id="automation-insights-message" class="text-sm font-semibold text-text"></p>
+                <p id="automation-insights-timestamp" class="text-xs text-muted"></p>
+              </div>
+              <div id="automation-insights-grid" class="mt-4 grid gap-3 sm:grid-cols-2"></div>
+            </div>
+            <div id="automation-history" class="mt-6 hidden">
+              <div class="flex flex-wrap items-center justify-between gap-3">
+                <span class="text-xs uppercase tracking-wide text-muted">История сигналов</span>
+                <button
+                  id="automation-history-clear"
+                  type="button"
+                  class="text-[11px] font-semibold uppercase tracking-wide text-muted transition hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
+                >
+                  Очистить
+                </button>
+              </div>
+              <p id="automation-history-empty" class="mt-3 text-xs text-muted">
+                История сигналов появится после получения webhook отчётов.
+              </p>
+              <div id="automation-history-list" class="mt-4 space-y-4"></div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add a clearable "История сигналов" block to the automation panel so webhook письма фиксируются по дням
- persist входящие webhook payloads в localStorage и группировать их по дате с ключевыми полями отчёта
- синхронизировать обновление статуса автоматизации с отображением истории, даже когда endpoint возвращает 204 или ошибку

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d64b8712688320b6c5bafc740aea78