### PR TITLE
Add indicator database and MVRVZ gauge

### DIFF
--- a/dapp/пульс/src/style.css
+++ b/dapp/пульс/src/style.css
@@ -66,6 +66,97 @@
     @apply border border-grid/40 bg-card/80 backdrop-blur rounded-2xl shadow-card;
   }
 
+  .indicator-gauge {
+    @apply flex flex-col gap-2 rounded-2xl border border-grid/40 bg-card/80 p-4;
+  }
+
+  .indicator-gauge__track {
+    position: relative;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    border-radius: 9999px;
+    overflow: hidden;
+    min-height: 3.5rem;
+    background: linear-gradient(90deg, rgba(33, 37, 52, 0.85), rgba(33, 37, 52, 0.6));
+  }
+
+  .indicator-gauge__zone {
+    @apply flex items-center justify-center px-3 text-[10px] font-semibold uppercase tracking-[0.18em];
+    color: rgba(235, 237, 244, 0.82);
+    letter-spacing: 0.18em;
+  }
+
+  .indicator-gauge__zone--accumulation {
+    background: linear-gradient(135deg, rgba(70, 192, 120, 0.25), rgba(70, 192, 120, 0.45));
+  }
+
+  .indicator-gauge__zone--neutral {
+    background: linear-gradient(135deg, rgba(120, 120, 200, 0.2), rgba(120, 120, 200, 0.35));
+  }
+
+  .indicator-gauge__zone--distribution {
+    background: linear-gradient(135deg, rgba(220, 90, 120, 0.3), rgba(220, 90, 120, 0.5));
+  }
+
+  .indicator-gauge__needle {
+    position: absolute;
+    top: 0.75rem;
+    bottom: 0.75rem;
+    width: 0;
+    left: var(--needle-position, 50%);
+    transform: translateX(-50%);
+  }
+
+  .indicator-gauge__needle::before {
+    content: '';
+    position: absolute;
+    top: -0.75rem;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 9999px;
+    border: 3px solid rgba(12, 13, 19, 0.65);
+    background: var(--needle-color, #f3f4fa);
+    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.25);
+  }
+
+  .indicator-gauge__needle::after {
+    content: '';
+    position: absolute;
+    top: 1.5rem;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 0.35rem;
+    bottom: -0.85rem;
+    border-radius: 9999px;
+    background: linear-gradient(180deg, var(--needle-color, #f3f4fa), rgba(243, 244, 250, 0));
+  }
+
+  .indicator-gauge__labels {
+    @apply mt-2 flex items-center justify-between text-[11px] uppercase tracking-wide text-muted;
+  }
+
+  .indicator-gauge__summary {
+    @apply font-semibold text-text;
+  }
+
+  .indicator-gauge__details {
+    @apply grid gap-3;
+  }
+
+  .indicator-gauge__detail-item {
+    @apply rounded-xl bg-surface/70 p-4;
+  }
+
+  .indicator-gauge__detail-label {
+    @apply text-[11px] uppercase tracking-wide text-muted;
+  }
+
+  .indicator-gauge__detail-value {
+    @apply mt-2 text-sm font-semibold text-text;
+  }
+
   .ticker-container {
     @apply relative flex items-center overflow-hidden border-y border-grid/40 bg-card/80 px-4 py-2 text-xs text-muted md:text-sm;
   }

--- a/index.html
+++ b/index.html
@@ -375,6 +375,26 @@
               </div>
               <div id="automation-insights-grid" class="mt-4 grid gap-3 sm:grid-cols-2"></div>
             </div>
+            <div id="indicator-gauge-container" class="mt-6 hidden">
+              <div class="flex flex-col gap-3">
+                <span class="text-xs uppercase tracking-wide text-muted">MVRVZ индикатор</span>
+                <div class="indicator-gauge" role="img" aria-live="polite">
+                  <div class="indicator-gauge__track">
+                    <div class="indicator-gauge__zone indicator-gauge__zone--accumulation" aria-hidden="true">Накопление</div>
+                    <div class="indicator-gauge__zone indicator-gauge__zone--neutral" aria-hidden="true">Нейтрально</div>
+                    <div class="indicator-gauge__zone indicator-gauge__zone--distribution" aria-hidden="true">Перегрев</div>
+                    <div id="indicator-gauge-needle" class="indicator-gauge__needle" aria-hidden="true"></div>
+                  </div>
+                  <div class="indicator-gauge__labels" aria-hidden="true">
+                    <span>0</span>
+                    <span>1</span>
+                    <span>2</span>
+                  </div>
+                </div>
+                <p id="indicator-gauge-summary" class="indicator-gauge__summary text-sm text-muted"></p>
+              </div>
+              <div id="indicator-gauge-details" class="indicator-gauge__details mt-4 grid gap-3 sm:grid-cols-2"></div>
+            </div>
           </div>
         </div>
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "pulse-protocol",
       "version": "1.0.0",
       "dependencies": {
+        "better-sqlite3": "^9.6.0",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
@@ -964,6 +965,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.6.tgz",
@@ -972,6 +993,17 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/better-sqlite3": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
+      "integrity": "sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
       }
     },
     "node_modules/binary-extensions": {
@@ -985,6 +1017,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/body-parser": {
@@ -1066,6 +1118,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/bytes": {
@@ -1220,6 +1296,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -1456,6 +1538,30 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1473,6 +1579,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.1.tgz",
+      "integrity": "sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/didyoumean": {
@@ -1549,6 +1664,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -1645,6 +1769,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/express": {
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
@@ -1737,6 +1870,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -1817,6 +1956,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1887,6 +2032,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "10.4.5",
@@ -1996,10 +2147,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
@@ -2245,6 +2422,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -2261,6 +2450,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -2270,6 +2468,12 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.0.0",
@@ -2308,6 +2512,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -2315,6 +2525,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.77.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.77.0.tgz",
+      "integrity": "sha512-DSmt0OEcLoK4i3NuscSbGjOf3bqiDEutejqENSplMSFA/gmB8mkED9G4pKWnPl7MDU4rSHebKPHeitpDfyH0cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-releases": {
@@ -2385,6 +2607,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -2639,6 +2870,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2650,6 +2907,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/qs": {
@@ -2712,6 +2979,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -2720,6 +3002,20 @@
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -2878,6 +3174,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "0.19.0",
@@ -3060,6 +3368,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3077,6 +3430,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -3183,6 +3545,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/sucrase": {
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
@@ -3273,6 +3644,34 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -3342,6 +3741,18 @@
       "dev": true,
       "license": "0BSD"
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -3399,7 +3810,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {
@@ -3593,6 +4003,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "vite": "^5.4.8"
   },
   "dependencies": {
+    "better-sqlite3": "^9.6.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",

--- a/server/indicatorStorage.js
+++ b/server/indicatorStorage.js
@@ -1,0 +1,367 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+
+let db = null;
+let dbFilePath = null;
+
+const NORMALIZED_KEY_CACHE = new Map();
+
+const normalizeKey = (key) => {
+  const cacheKey = String(key ?? '');
+  if (NORMALIZED_KEY_CACHE.has(cacheKey)) {
+    return NORMALIZED_KEY_CACHE.get(cacheKey);
+  }
+
+  const normalized = cacheKey
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/_{2,}/g, '_')
+    .replace(/^_|_$/g, '');
+
+  NORMALIZED_KEY_CACHE.set(cacheKey, normalized);
+  return normalized;
+};
+
+const coerceString = (value) => {
+  if (value == null) {
+    return '';
+  }
+
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+
+  return '';
+};
+
+const coerceNumber = (value) => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.replace(/[^0-9.,-]/g, '').replace(',', '.');
+    const parsed = Number.parseFloat(normalized);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+};
+
+const coerceDateString = (value) => {
+  if (!value) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    const iso = value.toISOString();
+    return iso;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const fromNumber = new Date(value);
+    if (!Number.isNaN(fromNumber.getTime())) {
+      return fromNumber.toISOString();
+    }
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const numeric = Number(trimmed);
+    if (!Number.isNaN(numeric) && String(numeric).length >= 10) {
+      const fromNumeric = new Date(numeric);
+      if (!Number.isNaN(fromNumeric.getTime())) {
+        return fromNumeric.toISOString();
+      }
+    }
+
+    const parsed = new Date(trimmed);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.toISOString();
+    }
+
+    return trimmed;
+  }
+
+  return null;
+};
+
+const resolvePayloadValue = (payload, keys) => {
+  if (!payload || typeof payload !== 'object' || !Array.isArray(keys)) {
+    return undefined;
+  }
+
+  const normalizedEntries = new Map();
+
+  for (const [rawKey, value] of Object.entries(payload)) {
+    const normalized = normalizeKey(rawKey);
+    if (!normalizedEntries.has(normalized)) {
+      normalizedEntries.set(normalized, value);
+    }
+  }
+
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(payload, key)) {
+      const value = payload[key];
+      if (value !== undefined) {
+        return value;
+      }
+    }
+
+    const normalizedKey = normalizeKey(key);
+    if (normalizedEntries.has(normalizedKey)) {
+      const value = normalizedEntries.get(normalizedKey);
+      if (value !== undefined) {
+        return value;
+      }
+    }
+  }
+
+  return undefined;
+};
+
+const extractIndicatorPayload = (payload) => {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  if (payload.data && typeof payload.data === 'object' && !Array.isArray(payload.data)) {
+    return payload.data;
+  }
+
+  return payload;
+};
+
+const extractIndicatorRecord = (record) => {
+  if (!record || typeof record !== 'object') {
+    return null;
+  }
+
+  const payload = extractIndicatorPayload(record.payload ?? record.data ?? record);
+
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const ticker = coerceString(
+    resolvePayloadValue(payload, ['ticker', 'symbol', 'pair', 'market_pair', 'instrument'])
+  );
+  const exchange = coerceString(resolvePayloadValue(payload, ['exchange', 'venue', 'market']));
+  const timeframe = coerceString(resolvePayloadValue(payload, ['timeframe', 'interval', 'resolution']));
+  const condition = coerceString(resolvePayloadValue(payload, ['condition', 'rule', 'direction']));
+  const price = coerceNumber(resolvePayloadValue(payload, ['price', 'close', 'last_price']));
+  const mvrvzBtc = coerceNumber(resolvePayloadValue(payload, ['mvrvz_btc', 'mvrvzbtc', 'mvrvz_btc_value']));
+  const mvrvzEth = coerceNumber(resolvePayloadValue(payload, ['mvrvz_eth', 'mvrvzeth', 'mvrvz_eth_value']));
+  const message = coerceString(
+    resolvePayloadValue(payload, [
+      'message',
+      'alert',
+      'description',
+      'payload_alert_message',
+      'payload alert message'
+    ])
+  );
+  const source = coerceString(resolvePayloadValue(payload, ['source', 'origin', 'channel']));
+  const primaryAsset = coerceString(
+    resolvePayloadValue(payload, ['message_mvrvz', 'payload_alert_message_mvrvz', 'asset'])
+  );
+  const triggeredAt =
+    coerceDateString(record.triggeredAt ?? resolvePayloadValue(payload, ['triggered_at', 'time'])) ??
+    null;
+  const receivedAt = coerceDateString(record.receivedAt ?? resolvePayloadValue(payload, ['received_at'])) ?? null;
+
+  if (!ticker && mvrvzBtc == null && mvrvzEth == null && !message) {
+    return null;
+  }
+
+  return {
+    id: coerceString(record.id) || null,
+    event: coerceString(record.event) || null,
+    ticker: ticker || null,
+    exchange: exchange || null,
+    timeframe: timeframe || null,
+    condition: condition || null,
+    price,
+    mvrvz_btc: mvrvzBtc,
+    mvrvz_eth: mvrvzEth,
+    message: message || null,
+    source: source || null,
+    primary_asset: primaryAsset || null,
+    triggered_at: triggeredAt,
+    received_at: receivedAt,
+    raw_payload: JSON.stringify(payload)
+  };
+};
+
+export const initIndicatorStorage = async (dataDirectory) => {
+  if (!dataDirectory) {
+    throw new Error('Data directory is required to initialise indicator storage.');
+  }
+
+  await fs.mkdir(dataDirectory, { recursive: true });
+
+  dbFilePath = path.join(dataDirectory, 'indicator-values.db');
+  db = new Database(dbFilePath);
+  db.pragma('journal_mode = WAL');
+  db.pragma('synchronous = NORMAL');
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS indicator_events (
+      id TEXT PRIMARY KEY,
+      event TEXT,
+      ticker TEXT,
+      exchange TEXT,
+      timeframe TEXT,
+      condition TEXT,
+      price REAL,
+      mvrvz_btc REAL,
+      mvrvz_eth REAL,
+      message TEXT,
+      source TEXT,
+      primary_asset TEXT,
+      triggered_at TEXT,
+      received_at TEXT,
+      raw_payload TEXT NOT NULL
+    );
+  `);
+};
+
+export const storeIndicatorEvent = (record) => {
+  if (!db) {
+    throw new Error('Indicator storage is not initialised.');
+  }
+
+  const entry = extractIndicatorRecord(record);
+  if (!entry) {
+    return;
+  }
+
+  const stmt = db.prepare(`
+    INSERT INTO indicator_events (
+      id,
+      event,
+      ticker,
+      exchange,
+      timeframe,
+      condition,
+      price,
+      mvrvz_btc,
+      mvrvz_eth,
+      message,
+      source,
+      primary_asset,
+      triggered_at,
+      received_at,
+      raw_payload
+    ) VALUES (
+      @id,
+      @event,
+      @ticker,
+      @exchange,
+      @timeframe,
+      @condition,
+      @price,
+      @mvrvz_btc,
+      @mvrvz_eth,
+      @message,
+      @source,
+      @primary_asset,
+      @triggered_at,
+      @received_at,
+      @raw_payload
+    )
+    ON CONFLICT(id) DO UPDATE SET
+      event = excluded.event,
+      ticker = excluded.ticker,
+      exchange = excluded.exchange,
+      timeframe = excluded.timeframe,
+      condition = excluded.condition,
+      price = excluded.price,
+      mvrvz_btc = excluded.mvrvz_btc,
+      mvrvz_eth = excluded.mvrvz_eth,
+      message = excluded.message,
+      source = excluded.source,
+      primary_asset = excluded.primary_asset,
+      triggered_at = excluded.triggered_at,
+      received_at = excluded.received_at,
+      raw_payload = excluded.raw_payload;
+  `);
+
+  stmt.run(entry);
+};
+
+export const getLatestIndicatorEvent = () => {
+  if (!db) {
+    throw new Error('Indicator storage is not initialised.');
+  }
+
+  const row = db
+    .prepare(
+      `
+        SELECT *
+        FROM indicator_events
+        ORDER BY
+          COALESCE(received_at, triggered_at) DESC,
+          rowid DESC
+        LIMIT 1
+      `
+    )
+    .get();
+
+  if (!row) {
+    return null;
+  }
+
+  return {
+    ...row,
+    price: row.price != null ? Number(row.price) : null,
+    mvrvz_btc: row.mvrvz_btc != null ? Number(row.mvrvz_btc) : null,
+    mvrvz_eth: row.mvrvz_eth != null ? Number(row.mvrvz_eth) : null
+  };
+};
+
+export const getIndicatorHistory = (limit = 50) => {
+  if (!db) {
+    throw new Error('Indicator storage is not initialised.');
+  }
+
+  const safeLimit = Number.isInteger(limit) && limit > 0 ? Math.min(limit, 200) : 50;
+
+  const rows = db
+    .prepare(
+      `
+        SELECT *
+        FROM indicator_events
+        ORDER BY
+          COALESCE(received_at, triggered_at) DESC,
+          rowid DESC
+        LIMIT ?
+      `
+    )
+    .all(safeLimit);
+
+  return rows.map((row) => ({
+    ...row,
+    price: row.price != null ? Number(row.price) : null,
+    mvrvz_btc: row.mvrvz_btc != null ? Number(row.mvrvz_btc) : null,
+    mvrvz_eth: row.mvrvz_eth != null ? Number(row.mvrvz_eth) : null
+  }));
+};
+
+export const getIndicatorDatabasePath = () => dbFilePath;


### PR DESCRIPTION
## Summary
- add a persistent SQLite store for webhook indicator payloads and expose /api/indicator endpoints
- persist Zapier events into the indicator database alongside the existing log history
- render a new MVRVZ gauge with contextual details inside the signal panel and style it for the dashboard

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d66e12d90483209e37154d6af01aa3