### PR TITLE
Fix backfill script to use newest Zapier log entry

### DIFF
--- a/scripts/backfill-indicator.js
+++ b/scripts/backfill-indicator.js
@@ -1,0 +1,54 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  initIndicatorStorage,
+  storeIndicatorEvent,
+  getIndicatorDatabasePath,
+} from '../server/indicatorStorage.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const dataDirectory = path.resolve(__dirname, '../data');
+const logFilePath = path.join(dataDirectory, 'zapier-log.json');
+
+const loadLogEntries = async () => {
+  try {
+    const content = await fs.readFile(logFilePath, 'utf8');
+    const parsed = JSON.parse(content);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      console.error('[backfill-indicator] Failed to read log file:', error);
+    }
+    return [];
+  }
+};
+
+const main = async () => {
+  await initIndicatorStorage(dataDirectory);
+
+  const entries = await loadLogEntries();
+  if (entries.length === 0) {
+    console.log('[backfill-indicator] No entries to backfill.');
+    return;
+  }
+
+  // Entries are prepended in server/index.js, so index 0 is the most recent.
+  const latestEntry = entries[0] ?? entries[entries.length - 1];
+  if (!latestEntry) {
+    console.warn('[backfill-indicator] Unable to determine the latest entry.');
+    return;
+  }
+
+  await storeIndicatorEvent(latestEntry);
+  console.log(
+    `[backfill-indicator] Stored latest indicator event to ${getIndicatorDatabasePath()}.`,
+  );
+};
+
+main().catch((error) => {
+  console.error('[backfill-indicator] Unexpected error while backfilling:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a backfill helper that reads the Zapier log file and initialises indicator storage
- ensure the script selects the most recent entry (index 0) with a fallback to the last element and document the ordering

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6c0a9b62c832094a1c82b14b6cbc6